### PR TITLE
front-end validation

### DIFF
--- a/src/remote/e-commerce-api/authService.ts
+++ b/src/remote/e-commerce-api/authService.ts
@@ -18,9 +18,16 @@ export const apiLogout = async (): Promise<eCommerceApiResponse> => {
 }
 
 export const apiRegister = async (firstName: string, lastName: string, email: string, password: string): Promise<eCommerceApiResponse> => {
-    const response = await eCommerceClient.post<any>(
-        `${baseURL}/register`,
-        { firstname: firstName, lastName: lastName, email: email, password: password }
-    );
-    return { status: response.status, payload: response.data };
+    //throws on 400+ errors at least
+    try 
+    {
+        const response = await eCommerceClient.post<any>(
+            `${baseURL}/register`,
+            { firstname: firstName, lastName: lastName, email: email, password: password }
+        );
+        return { status: response.status, payload: response.data };
+    }
+    catch(error){
+        return {status: 400, payload:null}
+    }    
 }


### PR DESCRIPTION
Email will be red if basic email formula is not used (checks for `@` eventually followed by a `.` )
Email will show an error if email is already used.

Password will be red if it doesn't meet password requirements (Upper, lower, numbers, special characters, and minimal length of 8) currently don't invalidate special characters that don't fit `@$!%*?&` not sure of any benefits to doing so to begin with.
Password helper will also display missing requirements.

> currently trying to print tabs and new lines, but those don't show

added check to maker sure first name and last name don't get fed if empty

partially addresses with the other part being in the back end [pull request](https://github.com/revature-rss-adam-1300/e-commerce-backend/pull/13)
#11 